### PR TITLE
change floating ip check method to support multi_ext_net feature

### DIFF
--- a/fuel_health/config.py
+++ b/fuel_health/config.py
@@ -636,6 +636,8 @@ class NailgunConfig(object):
             self.cluster_id, self.network.network_provider)
         data = self.req_session.get(self.nailgun_url + api_url).json()
         self.network.raw_data = data
+        self.compute.segmentation_type = \
+            data['networking_parameters']['segmentation_type']
 
     def _parse_cluster_generated_data(self):
         api_url = '/api/clusters/%s/generated' % self.cluster_id

--- a/fuel_health/neutronmanager.py
+++ b/fuel_health/neutronmanager.py
@@ -66,12 +66,22 @@ class NeutronBaseTest(fuel_health.nmanager.NovaNetworkScenarioTest):
         return router
 
     def create_network(self, name):
-        internal_network_info = {
-            "network": {
-                "name": name,
-                "tenant_id": self.tenant_id
+        if self.segmentation_type == 'vlan':
+            internal_network_info = {
+                "network": {
+                    "name": name,
+                    "tenant_id": self.tenant_id,
+                    "provider:network_type": "vlan",
+                    "provider:physical_network": "physnet2"
+                }
             }
-        }
+        else:
+            internal_network_info = {
+                "network": {
+                    "name": name,
+                    "tenant_id": self.tenant_id,
+                }
+            }
 
         network = self.neutron_client.create_network(
             internal_network_info)['network']

--- a/fuel_health/neutronmanager.py
+++ b/fuel_health/neutronmanager.py
@@ -116,6 +116,15 @@ class NeutronBaseTest(fuel_health.nmanager.NovaNetworkScenarioTest):
     def _remove_network(self, network):
         self.neutron_client.delete_network(network['id'])
 
+    def _update_router(self, router, body=None):
+        if not body:
+            body = {"router": {"name": router['name']}}
+        self.neutron_client.update_router(router['id'], body)
+
+    def _get_router_host(self, router):
+        return self.neutron_client.list_l3_agent_hosting_routers(
+            router['id'])['agents'][0]['host']
+
     @classmethod
     def _clear_networks(cls):
 

--- a/fuel_health/nmanager.py
+++ b/fuel_health/nmanager.py
@@ -430,6 +430,7 @@ class NovaNetworkScenarioTest(OfficialClientTest):
             cls.pwd = cls.config.compute.controller_node_ssh_password
             cls.key = cls.config.compute.path_to_private_key
             cls.timeout = cls.config.compute.ssh_timeout
+            cls.segmentation_type = cls.config.compute.segmentation_type
             cls.tenant_id = cls.manager._get_identity_client(
                 cls.config.identity.admin_username,
                 cls.config.identity.admin_password,

--- a/fuel_health/nmanager.py
+++ b/fuel_health/nmanager.py
@@ -439,6 +439,7 @@ class NovaNetworkScenarioTest(OfficialClientTest):
             cls.error_msg = []
             cls.flavors = []
             cls.private_net = 'net04'
+            cls.router_host = None
 
     def setUp(self):
         super(NovaNetworkScenarioTest, self).setUp()
@@ -615,13 +616,14 @@ class NovaNetworkScenarioTest(OfficialClientTest):
                     cls.error_msg.append(exc)
                     LOG.debug(traceback.format_exc())
 
-    def _ping_ip_address(self, ip_address, timeout, retries):
-        def ping():
-            cmd = "ping -q -c1 -w10 %s" % ip_address
+    def _ping_ip_address(self, ip_address, timeout, retries, router):
+        def ping(router):
+            cmd = "ip netns exec qrouter-%s ping -q -c1 -w10 %s" \
+                % (router, ip_address)
 
-            if self.host:
+            if self.router_host:
                 try:
-                    ssh = SSHClient(self.host[0],
+                    ssh = SSHClient(self.router_host,
                                     self.usr, self.pwd,
                                     key_filename=self.key,
                                     timeout=timeout)
@@ -632,12 +634,10 @@ class NovaNetworkScenarioTest(OfficialClientTest):
                                           ssh.exec_command, cmd)
 
             else:
-                self.fail('Wrong tests configurations, one from the next '
-                          'parameters are empty controller_node_name or '
-                          'controller_node_ip ')
+                self.fail('Must provide router hosting agent.')
 
         # TODO Allow configuration of execution and sleep duration.
-        return fuel_health.test.call_until_true(ping, 40, 1)
+        return fuel_health.test.call_until_true(ping, 40, 1, router)
 
     def _ping_ip_address_from_instance(self, ip_address, timeout,
                                        retries, viaHost=None):
@@ -670,8 +670,9 @@ class NovaNetworkScenarioTest(OfficialClientTest):
         # TODO Allow configuration of execution and sleep duration.
         return fuel_health.test.call_until_true(ping, 40, 1)
 
-    def _check_vm_connectivity(self, ip_address, timeout, retries):
-        self.assertTrue(self._ping_ip_address(ip_address, timeout, retries),
+    def _check_vm_connectivity(self, ip_address, timeout, retries, router):
+        self.assertTrue(self._ping_ip_address(ip_address, timeout, retries,
+                                              router),
                         "Timed out waiting for %s to become "
                         "reachable. Please, check Network "
                         "configuration" % ip_address)


### PR DESCRIPTION
Check vm connectivity from router because that nic "br-ex" with network "net04_ext"
was in different vlan in multiple external network environment.

Remove check connectivity from vm method because sametimes the environment will not
connect to the external network.

Signed-off-by: blkart <blkart.org@gmail.com>